### PR TITLE
fix(android): add namespace for AGP 7 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace 'com.shaz.plugin.fist.flutter_internet_speed_test'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
It's not working in my project. I researched and reviewed the code and found the problem.
It requires a namespace for AGP 7 compatibity.